### PR TITLE
block: blk-core: fix typo on compiler guards

### DIFF
--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -1619,7 +1619,7 @@ static struct request *blk_old_get_request(struct request_queue *q,
 	return rq;
 }
 
-#if defined(UFSFEATURE_31) || defined(UFSFEATURE_31)
+#if defined(CONFIG_UFSFEATURE_31) || defined(CONFIG_UFSFEATURE_31)
 /* flags: BLK_MQ_REQ_PREEMPT and/or BLK_MQ_REQ_NOWAIT. */
 struct request *blk_old_get_request_no_ioc(struct request_queue *q,
                                unsigned int op, blk_mq_req_flags_t flags)


### PR DESCRIPTION
Change from UFSFEATURE_31 to CONFIG_UFSFEATURE_31 to fix undefined reference of blk_old_get_request_no_ioc in function ufshpb_issue_pre_req on drivers/scsi/ufs/ufshpb31.o at link time.