### PR TITLE
Fixes abnormal power consumption on UMI

### DIFF
--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -2056,9 +2056,13 @@ __setup("androidboot.bootdevice=", get_android_boot_dev);
  */
 static void ufs_qcom_parse_lpm(struct ufs_qcom_host *host)
 {
+#if IS_ENABLED(CONFIG_BOARD_UMI) || IS_ENABLED(CONFIG_BOARD_THYME)
+	host->disable_lpm = false;
+#else
 	struct device_node *node = host->hba->dev->of_node;
 
 	host->disable_lpm = of_property_read_bool(node, "qcom,disable-lpm");
+#endif
 	if (host->disable_lpm)
 		pr_info("%s: will disable all LPM modes\n", __func__);
 }


### PR DESCRIPTION
Abnormal power consumption has long existed in all rebase kernels because we ignored  the following changes from cmi-r-oss