### PR TITLE
Add strategy to exit rapid_soc_dec to fix 1% problem.

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen4.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen4.c
@@ -411,6 +411,7 @@ static bool fg_esr_fast_cal_en;
 
 static int fg_gen4_validate_soc_scale_mode(struct fg_gen4_chip *chip);
 static int fg_gen4_esr_fast_calib_config(struct fg_gen4_chip *chip, bool en);
+static int fg_gen4_rapid_soc_config(struct fg_gen4_chip *chip, bool en);
 
 static struct fg_sram_param pm8150b_v1_sram_params[] = {
 	PARAM(BATT_SOC, BATT_SOC_WORD, BATT_SOC_OFFSET, 4, 1, 1, 0, NULL,
@@ -1224,6 +1225,23 @@ static int fg_gen4_get_prop_soc_scale(struct fg_gen4_chip *chip)
 	chip->vbatt_res = chip->vbatt_avg - chip->dt.cutoff_volt_mv;
 	fg_dbg(fg, FG_FVSS, "Vbatt now=%d Vbatt avg=%d Vbatt res=%d\n",
 		chip->vbatt_now, chip->vbatt_avg, chip->vbatt_res);
+
+	/* Exit rapid soc decrease mode when battery voltage > 3700mV to recover real soc value */
+	if (chip->vbatt_avg > 3700) {
+		if (chip->dt.rapid_soc_dec_en) {
+			if(chip->rapid_soc_dec_en) {
+				fg_dbg(fg, FG_STATUS, "Vbatt > 3700, exit rapid soc decrease\n", fg->charge_status);
+				rc = fg_gen4_rapid_soc_config(chip, false);
+				if (rc < 0)
+					pr_err("Error in configuring for rapid SOC reduction rc:%d\n",
+						rc);
+				chip->rapid_soc_dec_en = false;
+			}
+		} else if (chip->vbatt_low) {
+			fg_dbg(fg, FG_STATUS, "Vbatt > 3700, reset vbatt_low = false\n", fg->charge_status);
+			chip->vbatt_low = false;
+		}
+	}
 
 	return rc;
 }


### PR DESCRIPTION
## Background

Some Xiaomi devices with PM8150 (qcom gen4) power management IC, mainly Snapdragon 865/870 devices including Redmi K30Pro/POCO F2 Pro, K30S Ultra, K40, Xiaomi 10. (Xiaomi 10 Pro is not included because it uses BQ27Z561 PMIC), there is a chance the battery level may stuck at 1%, even charging(actually it can be charged, but still displaying 1%) or reboot doesn't recover it. 

If you run into this situation, the only way to escape is trying to "reset" the PMIC, one way is just to let the battery drain, so the motherboard and PMIC would be completely powered off. Another way is by pressing the Volume Down & Power button for 60s+, power cycle into FASTBOOT around 10+ times, then the PMIC could be reset.

## What caused this

The qualcomm's PMIC driver `qpnp-fg-gen4.c`, it has a strategy called "rapid_soc_dec", when the battery is under-voltage(usually caused by an aging battery or/and low temperature with high current and low battery level), it will immediately report the battery level (aka. `soc` in the code) to 0% for asking the upper-level software to power off the system. (Actually that is bad, this is why some other phones sometimes suddenly power off when the battery is low or in a low-temperature environment). **There is no chance of exiting this state because the original design logic is powering off the device! This is the root reason for this "bug"!!**

However, Xiaomi Implemented a "smooth strategy" in the driver, that can let the battery level change "smoothly" without suddenly jumping to a very high or low value. So when it has entered "rapid_soc_dec" state, it will slowly and smoothly move to 1% (not reporting 0% because there are some other conditions that need to be met), then always stuck there, not powering off, and no chance of exiting this "rapid_soc_dec" state. Charging the battery is also not able to exit this state.

Even, rebooting/power cycling also doesn't work, because for entering "rapid_soc_dec" state, the parameters have been written to the PMIC register, so it reports 0% `soc` from the hardware, not the kernel/software thing. Even there is a "fg_gen4_shutdown" callback that seems to try to restore the value, but I don't know why it doesn't work on many devices, at least not my device. Some people say it can be solved by rebooting/power cycling the device, which means this callback working on these devices.

## The fix
Quite simple, just add an exit strategy of "rapid_soc_dec" state. Checking the battery voltage when it > 3700mV, then exit this state. 

Just check this commit, it is the code of the fix: https://github.com/liyafe1997/Xiaomi-fix-battery-one-percent/commit/83cb4c684d0a483e8c2c39f6ae80be428b855d25

Why did I choose the value 3700mV? I don't know exactly, It just seems for a battery that is at a relatively low charge (Like 20+%), still easy to go back to >3700mV when in a low load(current). If you connect to a charger surely it should go back to >3700.

This fix just makes sure 1. The battery/kernel accidentally entered that state, in a "enough charge level" like 20+ present. 2. At least it can escape this state when you charge the battery. If your battery voltage is really low and can not go back to 3700, it is better to just stay in this "rapid_soc_dec" state, reports 1% to you for asking you to charge the battery as soon as possible :)